### PR TITLE
Add unit testing for Preload

### DIFF
--- a/preload_test.go
+++ b/preload_test.go
@@ -178,6 +178,37 @@ func TestPreload_ManyToOne_Level1_Different_Pointer_Null(t *testing.T) {
 // 	assert.Equal(t, "spiderman-apikey", article.Author.APIKey.Key)
 // }
 
+func TestPreload_OneToOne_Level2_Either(t *testing.T) {
+	db, _, shutdown := dbConnection(t)
+	defer shutdown()
+
+	user := createUser(t, db, "spiderman")
+	assert.NotEmpty(t, user)
+	assert.Nil(t, sqlxx.Preload(db, &user, "Avatar"))
+	if !assert.NotNil(t, user.Avatar) {
+		t.FailNow()
+	}
+
+	article := createArticle(t, db, &user)
+	assert.NotEmpty(t, article)
+
+	comment := createComment(t, db, &user, &article)
+	assert.NotEmpty(t, comment)
+
+	// Level 1 with Value
+	assert.Nil(t, sqlxx.Preload(db, &comment, "User"))
+	assert.NotZero(t, comment.User)
+	assert.Equal(t, user.ID, comment.UserID)
+	assert.Equal(t, user.Username, comment.User.Username)
+
+	// Level 2 with Pointer
+	assert.Nil(t, sqlxx.Preload(db, &comment, "User.Avatar"))
+	if assert.NotNil(t, comment.User.Avatar) {
+		assert.Equal(t, user.Avatar.ID, comment.User.Avatar.ID)
+		assert.Equal(t, user.Avatar.Path, comment.User.Avatar.Path)
+	}
+}
+
 // func TestPreload_ManyToOne_Level2_Multiple(t *testing.T) {
 // 	db, _, shutdown := dbConnection(t)
 // 	defer shutdown()

--- a/sqlxx_test.go
+++ b/sqlxx_test.go
@@ -311,6 +311,17 @@ func loadData(t *testing.T, driver sqlxx.Driver) *TestData {
 	}
 }
 
+func createComment(t *testing.T, driver sqlxx.Driver, user *User, article *Article) Comment {
+	var id int
+	err := driver.QueryRowx("INSERT INTO comments (content, user_id, article_id) VALUES ($1, $2, $3) RETURNING id", "Lorem Ipsum", user.ID, article.ID).Scan(&id)
+	assert.Nil(t, err)
+
+	comment := Comment{}
+	assert.NoError(t, driver.Get(&comment, "SELECT * FROM comments WHERE id = $1", id))
+
+	return comment
+}
+
 func createArticle(t *testing.T, driver sqlxx.Driver, user *User) Article {
 	var id int
 	err := driver.QueryRowx("INSERT INTO articles (title, author_id, reviewer_id) VALUES ($1, $2, $3) RETURNING id", "Title", user.ID, user.ID).Scan(&id)


### PR DESCRIPTION
This pull request add a unit test for preload with a scenario when two level are defined with a one to one relationship. 

This "use case" was identified in Okpal.

> **NOTE:** `go test` will fail.