### PR TITLE
feat: restore support for JOIN

### DIFF
--- a/makroud_test.go
+++ b/makroud_test.go
@@ -3288,6 +3288,7 @@ type Meow struct {
 	CreatedAt time.Time   `makroud:"column:created"`
 	UpdatedAt time.Time   `makroud:"column:updated"`
 	DeletedAt pq.NullTime `makroud:"column:deleted"`
+	Cat       *Cat
 }
 
 func (Meow) TableName() string {

--- a/scripts/lint
+++ b/scripts/lint
@@ -10,8 +10,9 @@ fi
 SOURCE_DIRECTORY=$(dirname "${BASH_SOURCE[0]}")
 cd "${SOURCE_DIRECTORY}/.."
 
-if [[ -n $1 ]]; then
-    golangci-lint run "$1"
-else
-    golangci-lint run ./...
+OPTIONS=$(go list -f '{{.Dir}}' ./... | grep -v 'github.com/ulule/makroud/benchmark')
+if [ -n "$1" ]; then
+    OPTIONS="$@"
 fi
+
+golangci-lint run ${OPTIONS}

--- a/scripts/test
+++ b/scripts/test
@@ -12,7 +12,7 @@ if [[ ! -x "${gotest_path}" ]]; then
     go get -d -u -v github.com/stretchr/testify/require
 fi
 
-OPTIONS="./..."
+OPTIONS=$(go list -f '{{.Dir}}' ./... | grep -v 'github.com/ulule/makroud/benchmark')
 if [ -n "$1" ]; then
     OPTIONS="$@"
 fi


### PR DESCRIPTION
closes #53 

It doesn't handle `LEFT JOIN` since the associations must have `sql.Null*` when value is `nil`.