### PR TITLE
feat: don't start a goroutine to call log hook

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -16,8 +16,5 @@ func Log(driver Driver, query Query, duration time.Duration) {
 	if driver == nil && !driver.hasLogger() {
 		return
 	}
-	go func() {
-		query := query.String()
-		driver.logger().Log(query, duration)
-	}()
+	driver.logger().Log(query.String(), duration)
 }


### PR DESCRIPTION
I think it's better to let the log hook decide if it wants to log
asynchronously or not.

The main motivation for this PR is that we have tests where we count the
number of sql queries via the log hook, and these tests are flaky
because the log hook is asynchronous.