### PR TITLE
feat: add a ctx parameter to the log method

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -20,7 +20,7 @@ func Exec(ctx context.Context, driver Driver, stmt builder.Builder, dest ...inte
 		query := NewQuery(stmt)
 
 		defer func() {
-			Log(driver, query, time.Since(start))
+			Log(ctx, driver, query, time.Since(start))
 		}()
 	}
 
@@ -42,7 +42,7 @@ func RawExec(ctx context.Context, driver Driver, query string, dest ...interface
 		query := NewRawQuery(query)
 
 		defer func() {
-			Log(driver, query, time.Since(start))
+			Log(ctx, driver, query, time.Since(start))
 		}()
 	}
 
@@ -66,7 +66,7 @@ func RawExecArgs(ctx context.Context, driver Driver, query string, args []interf
 		}
 
 		defer func() {
-			Log(driver, query, time.Since(start))
+			Log(ctx, driver, query, time.Since(start))
 		}()
 	}
 

--- a/logger.go
+++ b/logger.go
@@ -1,20 +1,21 @@
 package makroud
 
 import (
+	"context"
 	"time"
 )
 
 // Logger is an observer that collect queries executed in makroud.
 type Logger interface {
 	// Log push what query was executed and its duration.
-	Log(query string, duration time.Duration)
+	Log(ctx context.Context, query string, duration time.Duration)
 }
 
 // Log will emmit given query on driver's attached Logger.
 // nolint: interfacer
-func Log(driver Driver, query Query, duration time.Duration) {
+func Log(ctx context.Context, driver Driver, query Query, duration time.Duration) {
 	if driver == nil || !driver.hasLogger() {
 		return
 	}
-	driver.logger().Log(query.String(), duration)
+	driver.logger().Log(ctx, query.String(), duration)
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -16,7 +16,7 @@ type logger struct {
 	logs chan string
 }
 
-func (e *logger) Log(query string, duration time.Duration) {
+func (e *logger) Log(ctx context.Context, query string, duration time.Duration) {
 	e.logs <- query
 }
 


### PR DESCRIPTION
The main motivation is to access values stored in the context from the
log hook, for example a request ID.