### PR TITLE
fix: defer rows.Close()

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -151,6 +151,7 @@ func execRowsOnModel(ctx context.Context, driver Driver, stmt Statement,
 	if err != nil {
 		return err
 	}
+	defer rows.Close()
 
 	base := reflectx.GetIndirectSliceType(dest)
 	list := reflectx.GetIndirectValue(dest)
@@ -181,6 +182,7 @@ func execRowsOnSchemaless(ctx context.Context, driver Driver,
 	if err != nil {
 		return err
 	}
+	defer rows.Close()
 
 	base := reflectx.GetIndirectSliceType(dest)
 	list := reflectx.GetIndirectValue(dest)
@@ -206,6 +208,7 @@ func execRowsOnScannable(ctx context.Context, driver Driver,
 	if err != nil {
 		return err
 	}
+	defer rows.Close()
 
 	columns, err := rows.Columns()
 	if err != nil {


### PR DESCRIPTION
This PR fixes a bug that occurs when we don't scan all the rows that we
receive from a query. For example it can occur when we have an error
before we scan the rows, or when we have an error scanning the first
rows when we receive multiple rows.

In such a case, the *sql.Rows is never closed, which prevents the
*sql.Conn to be reused. It's a leak. Depending on the settings, any
method of the underlying *sql.DB which requires creating a new *sql.Conn
may block forever.

Below is a code snippet to reproduce the issue:

```go
var (
    ctx    = context.Background()
    driver makroud.Driver
    dest   []struct {
        ID int64 `makroud:"id"`
    }
    builder = lk.Select("column").From("table")
)
for {
    if err := makroud.Exec(ctx, driver, builder, &dest); err != nil {
        fmt.Printf("%+v\n", err)
        continue
    }
}
```

We get an error after doing the query, and before scanning the rows.
After a few queries, no new query can be executed and the driver is
blocked.