### PR TITLE
Backport fix defer-rows-close on 0.8 version

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -153,6 +153,7 @@ func execRowsOnModel(ctx context.Context, driver Driver, stmt Statement,
 	if err != nil {
 		return err
 	}
+	defer rows.Close()
 
 	base := reflectx.GetIndirectSliceType(dest)
 	list := reflectx.GetIndirectValue(dest)
@@ -183,6 +184,7 @@ func execRowsOnSchemaless(ctx context.Context, driver Driver,
 	if err != nil {
 		return err
 	}
+	defer rows.Close()
 
 	base := reflectx.GetIndirectSliceType(dest)
 	list := reflectx.GetIndirectValue(dest)
@@ -208,6 +210,7 @@ func execRowsOnScannable(ctx context.Context, driver Driver,
 	if err != nil {
 		return err
 	}
+	defer rows.Close()
 
 	columns, err := rows.Columns()
 	if err != nil {

--- a/helpers.go
+++ b/helpers.go
@@ -153,7 +153,10 @@ func execRowsOnModel(ctx context.Context, driver Driver, stmt Statement,
 	if err != nil {
 		return err
 	}
-	defer rows.Close()
+	defer close(driver, rows, map[string]string{
+		"name":   schema.ModelName(),
+		"action": "exec-rows-on-model",
+	})
 
 	base := reflectx.GetIndirectSliceType(dest)
 	list := reflectx.GetIndirectValue(dest)
@@ -184,7 +187,10 @@ func execRowsOnSchemaless(ctx context.Context, driver Driver,
 	if err != nil {
 		return err
 	}
-	defer rows.Close()
+	defer close(driver, rows, map[string]string{
+		"name":   schemaless.Name(),
+		"action": "exec-rows-on-schemaless",
+	})
 
 	base := reflectx.GetIndirectSliceType(dest)
 	list := reflectx.GetIndirectValue(dest)
@@ -210,7 +216,9 @@ func execRowsOnScannable(ctx context.Context, driver Driver,
 	if err != nil {
 		return err
 	}
-	defer rows.Close()
+	defer close(driver, rows, map[string]string{
+		"action": "exec-rows-on-scannable",
+	})
 
 	columns, err := rows.Columns()
 	if err != nil {

--- a/schemaless.go
+++ b/schemaless.go
@@ -22,6 +22,11 @@ func (schema Schemaless) Type() reflect.Type {
 	return schema.rtype
 }
 
+// Name returns the type's name of the schema.
+func (schema Schemaless) Name() string {
+	return schema.rtype.Name()
+}
+
 // Columns returns schema columns.
 func (schema Schemaless) Columns() Columns {
 	columns := Columns{}


### PR DESCRIPTION
A mini backport of #100 for the 0.8 version.