### PR TITLE
feat: add NewFromDB constructor

### DIFF
--- a/client.go
+++ b/client.go
@@ -66,38 +66,6 @@ func NewWithOptions(options *ClientOptions) (*Client, error) {
 	return client, nil
 }
 
-// NewFromDB returns a new Client instance from an existing *sql.DB.
-func NewFromDB(db *sql.DB, options ...Option) (*Client, error) {
-	opts := NewClientOptions()
-	for _, option := range options {
-		if err := option(opts); err != nil {
-			return nil, err
-		}
-	}
-
-	node := &node{db: db}
-	node.EnableSavepoint(opts.SavepointEnabled)
-
-	client := &Client{
-		node: node,
-		rnd:  getEntropyForClient(opts),
-	}
-
-	if opts.WithCache {
-		client.cache = NewDriverCache()
-	}
-
-	if opts.Logger != nil {
-		client.log = opts.Logger
-	}
-
-	if opts.Observer != nil {
-		client.obs = opts.Observer
-	}
-
-	return client, nil
-}
-
 // Exec executes a statement using given arguments.
 func (c *Client) Exec(ctx context.Context, query string, args ...interface{}) error {
 	_, err := c.node.ExecContext(ctx, query, args...)

--- a/client.go
+++ b/client.go
@@ -66,6 +66,38 @@ func NewWithOptions(options *ClientOptions) (*Client, error) {
 	return client, nil
 }
 
+// NewFromDB returns a new Client instance from an existing *sql.DB.
+func NewFromDB(db *sql.DB, options ...Option) (*Client, error) {
+	opts := NewClientOptions()
+	for _, option := range options {
+		if err := option(opts); err != nil {
+			return nil, err
+		}
+	}
+
+	node := &node{db: db}
+	node.EnableSavepoint(opts.SavepointEnabled)
+
+	client := &Client{
+		node: node,
+		rnd:  getEntropyForClient(opts),
+	}
+
+	if opts.WithCache {
+		client.cache = NewDriverCache()
+	}
+
+	if opts.Logger != nil {
+		client.log = opts.Logger
+	}
+
+	if opts.Observer != nil {
+		client.obs = opts.Observer
+	}
+
+	return client, nil
+}
+
 // Exec executes a statement using given arguments.
 func (c *Client) Exec(ctx context.Context, query string, args ...interface{}) error {
 	_, err := c.node.ExecContext(ctx, query, args...)

--- a/node.go
+++ b/node.go
@@ -128,6 +128,11 @@ func Connect(driver string, dsn string) (Node, error) {
 	return node, nil
 }
 
+// NewNode returns a new Node.
+func NewNode(db *sql.DB) Node {
+	return &node{db: db}
+}
+
 // DriverName returns the driver name used by this connector.
 func (node *node) DriverName() string {
 	return node.driver


### PR DESCRIPTION
We would like to create a new `*Client` from our own `*sql.DB`. The background is that we want to manage `*sql.DB` options outside of the makroud package, and also instrument the `*sql.DB` at the driver level.