### PR TITLE
ref: query directly, instead of preparing and closing statements

### DIFF
--- a/client.go
+++ b/client.go
@@ -94,6 +94,15 @@ func (c *Client) Query(ctx context.Context, query string, args ...interface{}) (
 	return wrapRows(rows), nil
 }
 
+// QueryRow executes a statement returning a single row.
+func (c *Client) QueryRow(ctx context.Context, query string, args ...interface{}) (Row, error) {
+	rows, err := c.node.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, errors.Wrap(err, "makroud: cannot execute query")
+	}
+	return wrapRow(rows), nil
+}
+
 // MustQuery executes a statement that returns rows using given arguments.
 // If an error has occurred, it panics.
 func (c *Client) MustQuery(ctx context.Context, query string, args ...interface{}) Rows {

--- a/makroud.go
+++ b/makroud.go
@@ -22,6 +22,9 @@ type Driver interface {
 	// Query executes a statement that returns rows using given arguments.
 	Query(ctx context.Context, query string, args ...interface{}) (Rows, error)
 
+	// QueryRow executes a statement returning a single row.
+	QueryRow(ctx context.Context, query string, args ...interface{}) (Row, error)
+
 	// MustQuery executes a statement that returns rows using given arguments.
 	// If an error has occurred, it panics.
 	MustQuery(ctx context.Context, query string, args ...interface{}) Rows


### PR DESCRIPTION
Currently, we always prepare, execute and close sql statements (without
reusing statements), which makes 3 roundtrips to the sql server.

Also, note that the sql driver at github.com/lib/pq does not implement
database/sql/drver.ConnPrepareContext, which means we still make a
roundtrip to the server for preparing the statement, even if the context
is cancelled.

With this PR, we query the server directly with only one roundtrip,
which is a bit more efficient.

This change makes instrumenting the underlying `*sql.DB` at the
driver level a bit simpler too, as we are not forced to handle the
database/sql/driver.ConnPrepareContext case.