### PR TITLE
feat: don't make dest argument variadic

### DIFF
--- a/transaction_test.go
+++ b/transaction_test.go
@@ -102,10 +102,10 @@ func TestTransaction_Nested(t *testing.T) {
 		}
 
 		setCatName := func(driver makroud.Driver, name string) {
-			query := loukoum.Update("ztp_cat").Set(loukoum.Map{"name": name}).
-				Where(loukoum.Condition("id").Equal(cat.ID))
-			err := makroud.Exec(ctx, driver, query)
-			is.NoError(err)
+			q, args := loukoum.Update("ztp_cat").Set(loukoum.Map{"name": name}).
+				Where(loukoum.Condition("id").Equal(cat.ID)).
+				Query()
+			is.NoError(driver.Exec(ctx, q, args...))
 		}
 
 		// First transaction.


### PR DESCRIPTION
The API of the package is more clear if the dest argument of the Exec
function is not variadic. If users want to call the Exec function
without a dest argument, they can directly call driver.Exec instead.